### PR TITLE
enabled translataion through google

### DIFF
--- a/Flight_Prediction_Final/templates/index.html
+++ b/Flight_Prediction_Final/templates/index.html
@@ -35,6 +35,9 @@
                 <li><a href="{{ url_for( 'predict' ) }}">PREDICTION</a></li>
                 <!-- <li><a href="#">OVERVIEW</a></li> -->
                 <!-- <li><a href="#"><button class="btn success">CODE</button></a></li> -->
+                <li id="google_translate_element_container">
+                    <div id="google_translate_element"></div>
+                </li>
             </ul>
         </div>
     </section>
@@ -135,8 +138,15 @@
             </ul>
         </div>
     </footer>
-    
+    <script type="text/javascript">
+        function googleTranslateElementInit() {
+          new google.translate.TranslateElement({
+            pageLanguage: 'en', // Your site's original language
+            layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+          }, 'google_translate_element');
+        }
+    </script>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
 </body>
-
 </html>

--- a/Flight_Prediction_Final/templates/predict.html
+++ b/Flight_Prediction_Final/templates/predict.html
@@ -35,6 +35,9 @@
         <li><a href="{{ url_for( 'index' ) }}">HOME</a></li>
         <li><a class="active" href="{{ url_for( 'predict' ) }}">PREDICTION</a></li>
         <!-- <li><a href="#">OVERVIEW</a></li> -->
+        <li id="google_translate_element_container">
+          <div id="google_translate_element"></div>
+        </li>        
       </ul>
     </div>
   </section>
@@ -174,6 +177,15 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.4/jquery.min.js"
     integrity="sha512-pumBsjNRGGqkPzKHndZMaAG+bir374sORyzM3uulLV14lN5LyykqNk8eEeUlUkB3U0M4FApyaHraT65ihJhDpQ=="
     crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script type="text/javascript">
+      function googleTranslateElementInit() {
+        new google.translate.TranslateElement({
+          pageLanguage: 'en', // Your site's original language
+          layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+        }, 'google_translate_element');
+      }
+    </script>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Title:
Enable Translation via Google Translate Widget  #13 

Description:
Hi @krittika2004,

This pull request adds multi-language support to the project by integrating the Google Translate widget into both the index.html and predict.html pages. Here’s a summary of the changes:

Integration:
The Google Translate widget is now embedded in the navigation bar, enabling users to switch between languages dynamically without leaving the page.

Testing:
The changes have been tested locally, and the widget correctly translates the content. Screenshots below illustrate the new functionality and styling in action.

Screenshots:
![Screenshot 2025-02-16 134928](https://github.com/user-attachments/assets/fc9178f4-be88-49e7-b978-219b6e176542)
![Screenshot 2025-02-16 134956](https://github.com/user-attachments/assets/053c1e40-64cf-4b86-9f89-52ca2c83663f)

I believe this addition enhances the user experience by making our application more accessible to a global audience. Please let me know if you have any feedback or require further changes.

Thank you for your time and consideration!

Best regards,
Akshat Gupta